### PR TITLE
Replace plain string queries with Arel methods

### DIFF
--- a/lib/bitwise_attribute/active_record_methods.rb
+++ b/lib/bitwise_attribute/active_record_methods.rb
@@ -8,10 +8,10 @@ module BitwiseAttribute
 
         return none unless keys&.any?
 
-        records = where((arel_table[column_name] & mapping[keys.first]).eq(mapping[keys.first]))
+        records = all
 
-        keys[1..-1].each do |key|
-          records = where((arel_table[column_name] & mapping[key]).eq(mapping[key]))
+        keys.each do |key|
+          records = records.where((arel_table[column_name] & mapping[key]).eq(mapping[key]))
         end
 
         records
@@ -22,9 +22,9 @@ module BitwiseAttribute
 
         return where.not(column_name => nil) unless keys&.any?
 
-        records = where((arel_table[column_name] & mapping[keys.first]).eq(mapping[keys.first]))
+        records = where('1=0')
 
-        keys[1..-1].each do |key|
+        keys.each do |key|
           records = records.or(where((arel_table[column_name] & mapping[key]).eq(mapping[key])))
         end
 
@@ -39,7 +39,7 @@ module BitwiseAttribute
         records = send("with_#{name}", keys)
 
         (mapping.keys - keys).each do |key|
-          records = where((arel_table[column_name] & mapping[key]).not_eq(mapping[key]))
+          records = records.where((arel_table[column_name] & mapping[key]).not_eq(mapping[key]))
         end
 
         records
@@ -50,10 +50,10 @@ module BitwiseAttribute
 
         return where(column_name => nil).or(where(column_name => 0)) unless keys&.any?
 
-        records = where((arel_table[column_name] & mapping[keys.first]).not_eq(mapping[keys.first]))
+        records = all
 
-        keys[1..-1].each do |key|
-          records = where((arel_table[column_name] & mapping[key]).not_eq(mapping[key]))
+        keys.each do |key|
+          records = records.where((arel_table[column_name] & mapping[key]).not_eq(mapping[key]))
         end
 
         records

--- a/spec/bitwise_attribute/active_record_methods_spec.rb
+++ b/spec/bitwise_attribute/active_record_methods_spec.rb
@@ -21,14 +21,14 @@ class User < ActiveRecord::Base
 end
 
 RSpec.describe BitwiseAttribute::ActiveRecordMethods do
-  let(:u1) { User.create!(roles: [:std]) }
-  let(:u2) { User.create!(roles: [:mod]) }
-  let(:u3) { User.create!(roles: [:a1]) }
+  let!(:u1) { User.create!(roles: [:std]) }
+  let!(:u2) { User.create!(roles: [:mod]) }
+  let!(:u3) { User.create!(roles: [:a1]) }
 
-  let(:u4) { User.create!(roles: %i[std a1]) }
-  let(:u5) { User.create!(roles: %i[a1 mod std]) }
-  let(:u6) { User.create!(roles: %i[a1 a2 std]) }
-  let(:u7) { User.create!(roles: %i[std mod a1 a2]) }
+  let!(:u4) { User.create!(roles: %i[std a1]) }
+  let!(:u5) { User.create!(roles: %i[a1 mod std]) }
+  let!(:u6) { User.create!(roles: %i[a1 a2 std]) }
+  let!(:u7) { User.create!(roles: %i[std mod a1 a2]) }
 
   after { User.destroy_all }
 


### PR DESCRIPTION
Complex queries caused issues with non-ambiguous column